### PR TITLE
Fix NUI callback

### DIFF
--- a/html/scripts.js
+++ b/html/scripts.js
@@ -132,7 +132,7 @@ function startGame(time){
     let u = "fail";
         if(status)
             u = "success";
-    xhr.open("POST", `http://qb-lock/${u}`, true);
+    xhr.open("POST", `https://${GetParentResourceName()}/${u}`, true);
     xhr.setRequestHeader('Content-Type', 'application/json');
     xhr.send(JSON.stringify({}));
     streak = 0;


### PR DESCRIPTION
Initial Error Message:
```
CrBrowserMain/ Mixed Content: The page at 'https://cfx-nui-qb-lock/html/index.html' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://qb-lock/fail'. This request has been blocked; the content must be served over HTTPS. (@qb-lock/html/scripts.js:137)
```
Summary of Changes
- Added HTTPS
- Updated to latest NUI callback standards